### PR TITLE
Safely unwrap optional

### DIFF
--- a/ShareExtensionDemo/LinksViewController.swift
+++ b/ShareExtensionDemo/LinksViewController.swift
@@ -14,7 +14,10 @@ class LinksViewController: UITableViewController, SFSafariViewControllerDelegate
     
     var links: Array<String> {
         get {
-            return NSUserDefaults.standardUserDefaults().objectForKey(userDefaultsKey) as! Array<String>
+            if let linksFromUserDefaults = NSUserDefaults.standardUserDefaults().objectForKey(userDefaultsKey) {
+                return linksFromUserDefaults as! Array<String>
+            }
+            return []
         }
         set {
             NSUserDefaults.standardUserDefaults().setObject(newValue, forKey: userDefaultsKey)


### PR DESCRIPTION
If optional is nil, empty array is returned.
